### PR TITLE
[Feature] - Create two `Aggregate Events` for `Vídeo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # codeflix-admin-backend
 
-### feature now - Genre entity
+### feature now - Video Aggregate
 
 
 ![backend_admin_catalogo](https://github.com/user-attachments/assets/91128c92-ac6f-4af1-8f72-e55f687b82a4)

--- a/src/core/video/domain/__tests__/video-aggregate.spec.ts
+++ b/src/core/video/domain/__tests__/video-aggregate.spec.ts
@@ -1,0 +1,429 @@
+import { CastMemberId } from '../../../cast-member/domain/cast-member.aggregate';
+import { CategoryId } from '../../../category/domain/category.aggregate';
+import { GenreId } from '../../../genre/domain/genre.aggregate';
+import { Banner } from '../banner.vo';
+
+import { Rating } from '../rating.vo';
+import { ThumbnailHalf } from '../thumbnail-half.vo';
+import { Thumbnail } from '../thumbnail.vo';
+
+import { Trailer } from '../trailer.vo';
+import { VideoMedia } from '../video-media.vo';
+import { Video, VideoId } from '../video.aggregate';
+
+describe('Video Unit Tests', () => {
+  beforeEach(() => {
+    Video.prototype.validate = jest
+      .fn()
+      .mockImplementation(Video.prototype.validate);
+  });
+  test('constructor of video', () => {
+    const categoryId = new CategoryId();
+    const categoriesId = new Map<string, CategoryId>([
+      [categoryId.id, categoryId],
+    ]);
+    const genreId = new GenreId();
+    const genresId = new Map<string, GenreId>([[genreId.id, genreId]]);
+    const castMemberId = new CastMemberId();
+    const castMembersId = new Map<string, CastMemberId>([
+      [castMemberId.id, castMemberId],
+    ]);
+    const rating = Rating.createRL();
+    let video = new Video({
+      title: 'test title',
+      description: 'test description',
+      year_launched: 2020,
+      duration: 90,
+      rating,
+      is_opened: true,
+      is_published: true,
+      categories_id: categoriesId,
+      genres_id: genresId,
+      cast_members_id: castMembersId,
+    });
+    expect(video).toBeInstanceOf(Video);
+    expect(video.video_id).toBeInstanceOf(VideoId);
+    expect(video.title).toBe('test title');
+    expect(video.description).toBe('test description');
+    expect(video.year_launched).toBe(2020);
+    expect(video.duration).toBe(90);
+    expect(video.rating).toBeInstanceOf(Rating);
+    expect(video.is_opened).toBe(true);
+    expect(video.is_published).toBe(true);
+    expect(video.banner).toBeNull();
+    expect(video.thumbnail).toBeNull();
+    expect(video.thumbnail_half).toBeNull();
+    expect(video.trailer).toBeNull();
+    expect(video.video).toBeNull();
+    expect(video.categories_id).toEqual(categoriesId);
+    expect(video.genres_id).toEqual(genresId);
+    expect(video.cast_members_id).toEqual(castMembersId);
+    expect(video.created_at).toBeInstanceOf(Date);
+
+    const banner = new Banner({
+      name: 'test name banner',
+      location: 'test location banner',
+    });
+
+    const thumbnail = new Thumbnail({
+      name: 'test name thumbnail',
+      location: 'test location thumbnail',
+    });
+
+    const thumbnailHalf = new ThumbnailHalf({
+      name: 'test name thumbnail half',
+      location: 'test location thumbnail half',
+    });
+
+    const trailer = Trailer.create({
+      name: 'test name trailer',
+      raw_location: 'test raw location trailer',
+    });
+
+    const videoMedia = VideoMedia.create({
+      name: 'test name video',
+      raw_location: 'test raw location video',
+    });
+
+    video = new Video({
+      title: 'test title',
+      description: 'test description',
+      year_launched: 2020,
+      duration: 90,
+      rating,
+      is_opened: true,
+      is_published: true,
+      banner,
+      thumbnail,
+      thumbnail_half: thumbnailHalf,
+      trailer,
+      video: videoMedia,
+      categories_id: categoriesId,
+      genres_id: genresId,
+      cast_members_id: castMembersId,
+    });
+
+    expect(video).toBeInstanceOf(Video);
+    expect(video.video_id).toBeInstanceOf(VideoId);
+    expect(video.title).toBe('test title');
+    expect(video.description).toBe('test description');
+    expect(video.year_launched).toBe(2020);
+    expect(video.duration).toBe(90);
+    expect(video.rating).toBeInstanceOf(Rating);
+    expect(video.is_opened).toBe(true);
+    expect(video.is_published).toBe(true);
+    expect(video.banner).toEqual(banner);
+    expect(video.thumbnail).toEqual(thumbnail);
+    expect(video.thumbnail_half).toEqual(thumbnailHalf);
+    expect(video.trailer).toEqual(trailer);
+    expect(video.video).toEqual(videoMedia);
+    expect(video.categories_id).toEqual(categoriesId);
+    expect(video.genres_id).toEqual(genresId);
+    expect(video.cast_members_id).toEqual(castMembersId);
+    expect(video.created_at).toBeInstanceOf(Date);
+  });
+
+  describe('video_id field', () => {
+    const arrange = [
+      {},
+      { id: null },
+      { id: undefined },
+      { id: new VideoId() },
+    ];
+
+    test.each(arrange)('when props is %j', (item) => {
+      const genre = new Video(item as any);
+      expect(genre.video_id).toBeInstanceOf(VideoId);
+    });
+  });
+
+  describe('create command', () => {
+    test('should create a video and no publish video media', () => {
+      const categories_id = [new CategoryId()];
+      const genres_id = [new GenreId()];
+      const cast_members_id = [new CastMemberId()];
+
+      const spyOnVideCreated = jest.spyOn(Video.prototype, 'onVideoCreated');
+      const tryMarkAsPublished = jest.spyOn(
+        Video.prototype as any,
+        'tryMarkAsPublished',
+      );
+      const video = Video.create({
+        title: 'test title',
+        description: 'test description',
+        year_launched: 2020,
+        duration: 90,
+        rating: Rating.createRL(),
+        is_opened: true,
+        categories_id,
+        genres_id,
+        cast_members_id,
+      });
+      expect(video.video_id).toBeInstanceOf(VideoId);
+      expect(video.title).toBe('test title');
+      expect(video.description).toBe('test description');
+      expect(video.year_launched).toBe(2020);
+      expect(video.duration).toBe(90);
+      expect(video.rating).toBeInstanceOf(Rating);
+      expect(video.is_opened).toBe(true);
+      expect(video.is_published).toBe(false);
+      expect(video.banner).toBeNull();
+      expect(video.thumbnail).toBeNull();
+      expect(video.thumbnail_half).toBeNull();
+      expect(video.trailer).toBeNull();
+      expect(video.video).toBeNull();
+      expect(video.categories_id).toEqual(
+        new Map(categories_id.map((id) => [id.id, id])),
+      );
+      expect(video.genres_id).toEqual(
+        new Map(genres_id.map((id) => [id.id, id])),
+      );
+      expect(video.cast_members_id).toEqual(
+        new Map(cast_members_id.map((id) => [id.id, id])),
+      );
+      expect(video.created_at).toBeInstanceOf(Date);
+      expect(video.is_published).toBeFalsy();
+      expect(spyOnVideCreated).toHaveBeenCalledTimes(1);
+      expect(tryMarkAsPublished).toHaveBeenCalledTimes(1);
+    });
+
+    test('should create a video and published video', () => {
+      const categories_id = [new CategoryId()];
+      const genres_id = [new GenreId()];
+      const cast_members_id = [new CastMemberId()];
+
+      const spyOnVideCreated = jest.spyOn(Video.prototype, 'onVideoCreated');
+      const tryMarkAsPublished = jest.spyOn(
+        Video.prototype as any,
+        'tryMarkAsPublished',
+      );
+
+      const trailer = Trailer.create({
+        name: 'test name trailer',
+        raw_location: 'test raw location trailer',
+      }).complete('test encoded_location trailer');
+      const videoMedia = VideoMedia.create({
+        name: 'test name video',
+        raw_location: 'test raw location video',
+      }).complete('test encoded_location video');
+
+      const video = Video.create({
+        title: 'test title',
+        description: 'test description',
+        year_launched: 2020,
+        duration: 90,
+        rating: Rating.createRL(),
+        is_opened: true,
+        trailer,
+        video: videoMedia,
+        categories_id,
+        genres_id,
+        cast_members_id,
+      });
+      expect(video.video_id).toBeInstanceOf(VideoId);
+      expect(video.title).toBe('test title');
+      expect(video.description).toBe('test description');
+      expect(video.year_launched).toBe(2020);
+      expect(video.duration).toBe(90);
+      expect(video.rating).toBeInstanceOf(Rating);
+      expect(video.is_opened).toBe(true);
+      expect(video.is_published).toBe(true);
+      expect(video.banner).toBeNull();
+      expect(video.thumbnail).toBeNull();
+      expect(video.thumbnail_half).toBeNull();
+      expect(video.trailer).toEqual(trailer);
+      expect(video.video).toEqual(videoMedia);
+      expect(video.categories_id).toEqual(
+        new Map(categories_id.map((id) => [id.id, id])),
+      );
+      expect(video.genres_id).toEqual(
+        new Map(genres_id.map((id) => [id.id, id])),
+      );
+      expect(video.cast_members_id).toEqual(
+        new Map(cast_members_id.map((id) => [id.id, id])),
+      );
+      expect(video.created_at).toBeInstanceOf(Date);
+      expect(video.is_published).toBeTruthy();
+      expect(spyOnVideCreated).toHaveBeenCalledTimes(1);
+      expect(tryMarkAsPublished).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('changeTitle method', () => {
+    test('should change title', () => {
+      const video = Video.fake().aVideoWithoutMedias().build();
+      video.changeTitle('test title');
+      expect(video.title).toBe('test title');
+      expect(Video.prototype.validate).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('changeDescription method', () => {
+    test('should change description', () => {
+      const video = Video.fake().aVideoWithoutMedias().build();
+      video.changeDescription('test description');
+      expect(video.description).toBe('test description');
+    });
+  });
+
+  describe('changeYearLaunched method', () => {
+    test('should change year launched', () => {
+      const video = Video.fake().aVideoWithoutMedias().build();
+      video.changeYearLaunched(2020);
+      expect(video.year_launched).toBe(2020);
+    });
+  });
+
+  describe('changeDuration method', () => {
+    test('should change duration', () => {
+      const video = Video.fake().aVideoWithoutMedias().build();
+      video.changeDuration(90);
+      expect(video.duration).toBe(90);
+    });
+  });
+
+  describe('changeRating method', () => {
+    test('should change rating', () => {
+      const video = Video.fake().aVideoWithoutMedias().build();
+      const rating = Rating.createRL();
+      video.changeRating(rating);
+      expect(video.rating).toBe(rating);
+    });
+  });
+
+  describe('markAsOpened method', () => {
+    test('should mark as opened', () => {
+      const video = Video.fake().aVideoWithoutMedias().build();
+      video.markAsOpened();
+      expect(video.is_opened).toBeTruthy();
+    });
+  });
+
+  describe('markAsNotOpened method', () => {
+    test('should mark as not opened', () => {
+      const video = Video.fake().aVideoWithoutMedias().build();
+      video.markAsNotOpened();
+      expect(video.is_opened).toBeFalsy();
+    });
+  });
+
+  describe('replaceBanner method', () => {
+    test('should replace banner', () => {
+      const video = Video.fake().aVideoWithoutMedias().build();
+      const banner = new Banner({
+        name: 'test name banner',
+        location: 'test location banner',
+      });
+      video.replaceBanner(banner);
+      expect(video.banner).toEqual(banner);
+    });
+  });
+
+  describe('replaceThumbnail method', () => {
+    test('should replace thumbnail', () => {
+      const video = Video.fake().aVideoWithoutMedias().build();
+      const thumbnail = new Thumbnail({
+        name: 'test name thumbnail',
+        location: 'test location thumbnail',
+      });
+      video.replaceThumbnail(thumbnail);
+      expect(video.thumbnail).toEqual(thumbnail);
+    });
+  });
+
+  describe('replaceThumbnailHalf method', () => {
+    test('should replace thumbnail half', () => {
+      const video = Video.fake().aVideoWithoutMedias().build();
+      const thumbnailHalf = new ThumbnailHalf({
+        name: 'test name thumbnail half',
+        location: 'test location thumbnail half',
+      });
+      video.replaceThumbnailHalf(thumbnailHalf);
+      expect(video.thumbnail_half).toEqual(thumbnailHalf);
+    });
+  });
+
+  describe('replaceTrailer method', () => {
+    test('should replace trailer', () => {
+      const video = Video.fake().aVideoWithoutMedias().build();
+      const trailer = Trailer.create({
+        name: 'test name trailer',
+        raw_location: 'test raw location trailer',
+      });
+      video.replaceTrailer(trailer);
+      expect(video.trailer).toEqual(trailer);
+    });
+  });
+
+  describe('replaceVideo method', () => {
+    test('should replace video', () => {
+      const video = Video.fake().aVideoWithoutMedias().build();
+      const videoMedia = VideoMedia.create({
+        name: 'test name video',
+        raw_location: 'test raw location video',
+      });
+      video.replaceVideo(videoMedia);
+      expect(video.video).toEqual(videoMedia);
+    });
+  });
+
+  test('should add category id', () => {
+    const categoryId = new CategoryId();
+    const video = Video.fake().aVideoWithoutMedias().build();
+    video.addCategoryId(categoryId);
+    expect(video.categories_id.size).toBe(2);
+    expect(video.categories_id.get(categoryId.id)).toBe(categoryId);
+  });
+
+  test('tryMarkAsPublished method', () => {
+    let video = Video.fake().aVideoWithoutMedias().build();
+    video['tryMarkAsPublished']();
+    expect(video.is_published).toBeFalsy();
+
+    video = Video.fake().aVideoWithoutMedias().build();
+    const trailer = Trailer.create({
+      name: 'test name trailer',
+      raw_location: 'test raw location trailer',
+    }).complete('test encoded_location trailer');
+    const videoMedia = VideoMedia.create({
+      name: 'test name video',
+      raw_location: 'test raw location video',
+    }).complete('test encoded_location video');
+
+    video.replaceTrailer(trailer);
+    video.replaceVideo(videoMedia);
+    video['tryMarkAsPublished']();
+    expect(video.is_published).toBeTruthy();
+  });
+});
+
+describe('Video Validator', () => {
+  describe('create command', () => {
+    test('should an invalid video with title property', () => {
+      const video = Video.create({
+        title: 't'.repeat(256),
+        categories_id: [new CategoryId()],
+        genres_id: [new GenreId()],
+        cast_members_id: [new CastMemberId()],
+      } as any);
+      expect(video.notification.hasErrors()).toBe(true);
+      expect(video.notification).notificationContainsErrorMessages([
+        {
+          title: ['title must be shorter than or equal to 255 characters'],
+        },
+      ]);
+    });
+  });
+  describe('changeTitle method', () => {
+    it('should a invalid video using title property', () => {
+      const video = Video.fake().aVideoWithoutMedias().build();
+      video.changeTitle('t'.repeat(256));
+      expect(video.notification.hasErrors()).toBe(true);
+      expect(video.notification).notificationContainsErrorMessages([
+        {
+          title: ['title must be shorter than or equal to 255 characters'],
+        },
+      ]);
+    });
+  });
+});

--- a/src/core/video/domain/domain-events/video-audio-media-replaced.event.ts
+++ b/src/core/video/domain/domain-events/video-audio-media-replaced.event.ts
@@ -1,0 +1,58 @@
+import {
+  IDomainEvent,
+  IIntegrationEvent,
+} from '../../../shared/domain/events/domain-event.interface';
+import { Trailer } from '../trailer.vo';
+import { VideoMedia } from '../video-media.vo';
+import { VideoId } from '../video.aggregate';
+
+type VideoAudioMediaReplacedProps = {
+  aggregate_id: VideoId;
+  media: Trailer | VideoMedia;
+  media_type: 'trailer' | 'video';
+};
+
+export class VideoAudioMediaReplaced implements IDomainEvent {
+  aggregate_id: VideoId;
+  occurred_on: Date;
+  event_version: number;
+
+  readonly media: Trailer | VideoMedia;
+  readonly media_type: 'trailer' | 'video';
+
+  constructor(props: VideoAudioMediaReplacedProps) {
+    this.aggregate_id = props.aggregate_id;
+    this.media = props.media;
+    this.media_type = props.media_type;
+    this.occurred_on = new Date();
+    this.event_version = 1;
+  }
+
+  getIntegrationEvent(): VideoAudioMediaUploadedIntegrationEvent {
+    return new VideoAudioMediaUploadedIntegrationEvent(this);
+  }
+}
+
+export class VideoAudioMediaUploadedIntegrationEvent
+  implements IIntegrationEvent
+{
+  //resource_id: string;
+  //file_path: string;
+
+  declare event_name: string;
+  declare payload: any;
+  declare event_version: number;
+  declare occurred_on: Date;
+
+  constructor(event: VideoAudioMediaReplaced) {
+    this['resource_id'] = `${event.aggregate_id.id}.${event.media_type}`;
+    this['file_path'] = event.media.raw_url;
+    // this.event_version = event.event_version;
+    // this.occurred_on = event.occurred_on;
+    // this.payload = {
+    //   video_id: event.aggregate_id.id,
+    //   media: event.media.toJSON(),
+    // };
+    // this.event_name = this.constructor.name;
+  }
+}

--- a/src/core/video/domain/domain-events/video-created.event.ts
+++ b/src/core/video/domain/domain-events/video-created.event.ts
@@ -1,0 +1,76 @@
+import { CastMemberId } from '../../../cast-member/domain/cast-member.aggregate';
+import { CategoryId } from '../../../category/domain/category.aggregate';
+import { GenreId } from '../../../genre/domain/genre.aggregate';
+import { IDomainEvent } from '../../../shared/domain/events/domain-event.interface';
+import { Banner } from '../banner.vo';
+import { Rating } from '../rating.vo';
+import { ThumbnailHalf } from '../thumbnail-half.vo';
+import { Thumbnail } from '../thumbnail.vo';
+import { Trailer } from '../trailer.vo';
+import { VideoMedia } from '../video-media.vo';
+import { VideoId } from '../video.aggregate';
+
+export type VideoCreatedEventProps = {
+  video_id: VideoId;
+  title: string;
+  description: string;
+  year_launched: number;
+  duration: number;
+  rating: Rating;
+  is_opened: boolean;
+  is_published: boolean;
+  banner: Banner | null;
+  thumbnail: Thumbnail | null;
+  thumbnail_half: ThumbnailHalf | null;
+  trailer: Trailer | null;
+  video: VideoMedia | null;
+  categories_id: CategoryId[];
+  genres_id: GenreId[];
+  cast_members_id: CastMemberId[];
+  created_at: Date;
+};
+
+export class VideoCreatedEvent implements IDomainEvent {
+  readonly aggregate_id: VideoId;
+  readonly occurred_on: Date;
+  readonly event_version: number;
+
+  readonly title: string;
+  readonly description: string;
+  readonly year_launched: number;
+  readonly duration: number;
+  readonly rating: Rating;
+  readonly is_opened: boolean;
+  readonly is_published: boolean;
+  readonly banner: Banner | null;
+  readonly thumbnail: Thumbnail | null;
+  readonly thumbnail_half: ThumbnailHalf | null;
+  readonly trailer: Trailer | null;
+  readonly video: VideoMedia | null;
+  readonly categories_id: CategoryId[];
+  readonly genres_id: GenreId[];
+  readonly cast_members_id: CastMemberId[];
+  readonly created_at: Date;
+
+  constructor(props: VideoCreatedEventProps) {
+    this.aggregate_id = props.video_id;
+    this.title = props.title;
+    this.description = props.description;
+    this.year_launched = props.year_launched;
+    this.duration = props.duration;
+    this.rating = props.rating;
+    this.is_opened = props.is_opened;
+    this.is_published = props.is_published;
+    this.banner = props.banner;
+    this.thumbnail = props.thumbnail;
+    this.thumbnail_half = props.thumbnail_half;
+    this.trailer = props.trailer;
+    this.video = props.video;
+    this.categories_id = props.categories_id;
+    this.genres_id = props.genres_id;
+    this.cast_members_id = props.cast_members_id;
+    this.created_at = props.created_at;
+    this.occurred_on = new Date();
+    this.event_version = 1;
+  }
+}

--- a/src/core/video/domain/video.aggregate.ts
+++ b/src/core/video/domain/video.aggregate.ts
@@ -11,6 +11,9 @@ import { Thumbnail } from './thumbnail.vo';
 import { Trailer } from './trailer.vo';
 import { VideoMedia } from './video-media.vo';
 
+import { AudioVideoMediaStatus } from '@core/shared/domain/value-objects/audio-video-media.vo';
+import { VideoAudioMediaReplaced } from './domain-events/video-audio-media-replaced.event';
+import { VideoCreatedEvent } from './domain-events/video-created.event';
 import { VideoFakeBuilder } from './video-fake.builder';
 import VideoValidatorFactory from './video.validator';
 
@@ -100,6 +103,16 @@ export class Video extends AggregateRoot {
     this.genres_id = props.genres_id;
     this.cast_members_id = props.cast_members_id;
     this.created_at = props.created_at ?? new Date();
+
+    this.registerHandler(
+      VideoCreatedEvent.name,
+      this.onVideoCreated.bind(this),
+    );
+
+    this.registerHandler(
+      VideoAudioMediaReplaced.name,
+      this.onAudioVideoMediaReplaced.bind(this),
+    );
   }
 
   static create(props: VideoCreateCommand) {
@@ -111,7 +124,27 @@ export class Video extends AggregateRoot {
       is_published: false,
     });
     video.validate(['title']);
-
+    video.applyEvent(
+      new VideoCreatedEvent({
+        video_id: video.video_id,
+        title: video.title,
+        description: video.description,
+        year_launched: video.year_launched,
+        duration: video.duration,
+        rating: video.rating,
+        is_opened: video.is_opened,
+        is_published: video.is_published,
+        banner: video.banner,
+        thumbnail: video.thumbnail,
+        thumbnail_half: video.thumbnail_half,
+        trailer: video.trailer,
+        video: video.video,
+        categories_id: Array.from(video.categories_id.values()),
+        genres_id: Array.from(video.genres_id.values()),
+        cast_members_id: Array.from(video.cast_members_id.values()),
+        created_at: video.created_at,
+      }),
+    );
     return video;
   }
 
@@ -158,10 +191,24 @@ export class Video extends AggregateRoot {
 
   replaceTrailer(trailer: Trailer): void {
     this.trailer = trailer;
+    this.applyEvent(
+      new VideoAudioMediaReplaced({
+        aggregate_id: this.video_id,
+        media: trailer,
+        media_type: 'trailer',
+      }),
+    );
   }
 
   replaceVideo(video: VideoMedia): void {
     this.video = video;
+    this.applyEvent(
+      new VideoAudioMediaReplaced({
+        aggregate_id: this.video_id,
+        media: video,
+        media_type: 'video',
+      }),
+    );
   }
 
   addCategoryId(categoryId: CategoryId): void {
@@ -208,6 +255,33 @@ export class Video extends AggregateRoot {
       throw new Error('Cast Members id is empty');
     }
     this.cast_members_id = new Map(castMembersId.map((id) => [id.id, id]));
+  }
+
+  onVideoCreated(_event: VideoCreatedEvent) {
+    if (this.is_published) {
+      return;
+    }
+
+    this.tryMarkAsPublished();
+  }
+
+  onAudioVideoMediaReplaced(_event: VideoAudioMediaReplaced) {
+    if (this.is_published) {
+      return;
+    }
+
+    this.tryMarkAsPublished();
+  }
+
+  private tryMarkAsPublished() {
+    if (
+      this.trailer &&
+      this.video &&
+      this.trailer.status === AudioVideoMediaStatus.COMPLETED &&
+      this.video.status === AudioVideoMediaStatus.COMPLETED
+    ) {
+      this.is_published = true;
+    }
   }
 
   validate(fields?: string[]) {


### PR DESCRIPTION
## Completed  

### dispache event when created a video
### dispache event when video audio, media replaced
###  create test to `video aggregate`

## Commits
 - [feat: create two aggregate events for video](https://github.com/joaogbrieldev/codeflix-admin-backend/commit/58891563c7394b1ef41c39001df3b2d5c1b46edd) 

@joaogbrieldev